### PR TITLE
Adding QueryEscape to support spaces in City and Country references in the API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Place your API Key into a file named api_key.txt (inside the same directory as t
 Get involved! This package has a *lot* of room for improvement. Below are a list of Go features which could be used in this package to good effect.
 
 * Tests! Testing has significant room for improvement.
-* Handle spaces in City name more gracefully - i.e. if space, convert to %20. This is a fairly easy first issue.
 
 Read the docs, write and try out some improvements and then make a pull request :smile: !
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	wb "github.com/alljames/weatherbit-go/pkg"
 	"os"
+	"net/url"
 )
 
 func main() {
@@ -16,8 +17,8 @@ func main() {
 	// holds easily customisable fields to make an API request
 	// The weatherbit-go package takes care of the rest!
 	params := wb.Parameters{
-		Lat:         51.4415, // Steam Crane Pub, Bristol
-		Lon:         -2.6017,
+		City: url.QueryEscape("New York"),
+		Country: url.QueryEscape("United States"),
 		Temporality: "history", // "current", "history", "forecast"
 		Apikey:      os.Getenv("WBITKEY"),
 
@@ -25,8 +26,8 @@ func main() {
 		Granularity: "hourly",
 
 		// required only for "history" queries
-		StartDate: "2019-04-08", // [YYYY-MM-DD OR YYYY-MM-DD:HH]
-		EndDate:   "2019-04-09", // [YYYY-MM-DD OR YYYY-MM-DD:HH]
+		StartDate: "2019-06-04", // [YYYY-MM-DD OR YYYY-MM-DD:HH]
+		EndDate:   "2019-06-05", // [YYYY-MM-DD OR YYYY-MM-DD:HH]
 	}
 
 	fmt.Println(wb.GetResponse(params))


### PR DESCRIPTION
This PR resolves the issue with spaces in the City and Country reference by escaping the string. 

A city such as `New York` will become `New%20York` when the API does the request to successfully return the data.

The example has also been updated to use City and Country instead of Longitude and Latitude. The start and end date was amended to support users who use the free tier api key.